### PR TITLE
feat: add PySide6 UI skeleton

### DIFF
--- a/Implementation Plan.md
+++ b/Implementation Plan.md
@@ -55,6 +55,8 @@ Demonstrate configuration editing round‑trip and validate schema coverage.
 ### Review
 Validate look & feel against the UI Interaction plan and confirm configuration edits flow through the UI.
 
+**Status:** Review completed and milestone approved.
+
 ## Milestone 3 – ClassificationService
 **Goal:** automated enrichment of source data into structured asset descriptions.
 

--- a/src/asset_organiser/__main__.py
+++ b/src/asset_organiser/__main__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from .config_service import ConfigService
+from .ui import MainWindow
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    config = ConfigService()
+    window = MainWindow(config)
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/asset_organiser/ui/__init__.py
+++ b/src/asset_organiser/ui/__init__.py
@@ -1,0 +1,8 @@
+"""UI components for Asset Organiser."""
+
+from .library import LibraryView
+from .main_window import MainWindow
+from .settings import SettingsView
+from .workspace import WorkspaceView
+
+__all__ = ["MainWindow", "WorkspaceView", "LibraryView", "SettingsView"]

--- a/src/asset_organiser/ui/library.py
+++ b/src/asset_organiser/ui/library.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QHBoxLayout, QListWidget, QTextEdit, QWidget
+
+
+class LibraryView(QWidget):
+    """Placeholder library view with grid and metadata panel."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        self.grid = QListWidget()
+        self.metadata = QTextEdit()
+        self.metadata.setReadOnly(True)
+        layout.addWidget(self.grid, 1)
+        layout.addWidget(self.metadata)

--- a/src/asset_organiser/ui/main_window.py
+++ b/src/asset_organiser/ui/main_window.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QStackedWidget,
+    QWidget,
+)
+
+from ..config_service import ConfigService
+from .library import LibraryView
+from .settings import SettingsView
+from .workspace import WorkspaceView
+
+
+class MainWindow(QMainWindow):
+    """Main application window with sidebar navigation."""
+
+    def __init__(
+        self,
+        config: ConfigService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Asset Organiser")
+        self._config = config
+
+        central = QWidget()
+        layout = QHBoxLayout(central)
+        self.sidebar = QListWidget()
+        self.stack = QStackedWidget()
+        layout.addWidget(self.sidebar)
+        layout.addWidget(self.stack, 1)
+        self.setCentralWidget(central)
+
+        # Views
+        self.views: Dict[str, QWidget] = {
+            "Workspace": WorkspaceView(),
+            "Library": LibraryView(),
+            "Settings": SettingsView(self._config),
+        }
+        for name, widget in self.views.items():
+            item = QListWidgetItem(name)
+            self.sidebar.addItem(item)
+            self.stack.addWidget(widget)
+
+        self.sidebar.currentRowChanged.connect(self.stack.setCurrentIndex)
+        self.sidebar.setCurrentRow(0)

--- a/src/asset_organiser/ui/settings.py
+++ b/src/asset_organiser/ui/settings.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (  # noqa: E501
+    QFormLayout,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..config_service import ConfigService
+
+
+class SettingsView(QWidget):
+    """Settings editor connected to ConfigService."""
+
+    def __init__(
+        self,
+        config: ConfigService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+
+        self.output_dir = QLineEdit()
+        self.metadata_name = QLineEdit()
+        form = QFormLayout()
+        form.addRow("Output Base Directory", self.output_dir)
+        form.addRow("Metadata Filename", self.metadata_name)
+
+        self.save_btn = QPushButton("Save")
+        self.save_btn.clicked.connect(self.save_settings)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(self.save_btn)
+
+        self.load_settings()
+
+    def load_settings(self) -> None:
+        settings = self._config.settings
+        self.output_dir.setText(settings.OUTPUT_BASE_DIR)
+        self.metadata_name.setText(settings.METADATA_FILENAME)
+
+    def save_settings(self) -> None:
+        settings = self._config.settings
+        settings.OUTPUT_BASE_DIR = self.output_dir.text()
+        settings.METADATA_FILENAME = self.metadata_name.text()
+        self._config.settings = settings
+        self._config.save_settings()

--- a/src/asset_organiser/ui/workspace.py
+++ b/src/asset_organiser/ui/workspace.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from PySide6.QtWidgets import (  # noqa: E501
+    QLabel,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class WorkspaceView(QWidget):
+    """Workspace view with drag-and-drop area and placeholder tree."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Drag files here"))
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels(["Source/Asset/File"])
+        layout.addWidget(self.tree, 1)
+
+    # Drag-and-drop events
+    def dragEnterEvent(self, event) -> None:  # type: ignore[override]
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    def dropEvent(self, event) -> None:  # type: ignore[override]
+        paths = [Path(url.toLocalFile()) for url in event.mimeData().urls()]
+        self.add_paths(paths)
+        event.acceptProposedAction()
+
+    # Helper for tests
+    def add_paths(self, paths: Iterable[Path]) -> None:
+        for path in paths:
+            item = QTreeWidgetItem([path.name])
+            self.tree.addTopLevelItem(item)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,47 @@
+import os
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
+
+from asset_organiser import ConfigService
+from asset_organiser.ui import MainWindow, WorkspaceView
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def test_main_window_loads_and_saves_settings(tmp_path: Path) -> None:
+    app = QApplication.instance() or QApplication([])
+
+    cfg_path = tmp_path / "settings.json"
+    service = ConfigService(app_config_path=cfg_path)
+    window = MainWindow(service)
+
+    # Sidebar has expected tabs
+    count = window.sidebar.count()
+    items = [window.sidebar.item(i).text() for i in range(count)]
+    assert items == ["Workspace", "Library", "Settings"]
+
+    # Switch to settings view and modify value
+    window.sidebar.setCurrentRow(2)
+    settings_view = window.views["Settings"]
+    settings_view.output_dir.setText("/tmp")
+    QTest.mouseClick(settings_view.save_btn, Qt.LeftButton)
+
+    assert service.settings.OUTPUT_BASE_DIR == "/tmp"
+
+    window.close()
+    app.quit()
+
+
+def test_workspace_adds_items(tmp_path: Path) -> None:
+    app = QApplication.instance() or QApplication([])
+    view = WorkspaceView()
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("x")
+    view.add_paths([file_path])
+    assert view.tree.topLevelItemCount() == 1
+    assert view.tree.topLevelItem(0).text(0) == "file.txt"
+    view.deleteLater()
+    app.quit()


### PR DESCRIPTION
## Summary
- add entry point to launch PySide6 app
- build main window with sidebar navigation and placeholder views
- connect settings form to ConfigService and add basic UI tests
- mark milestone 2 as completed in implementation plan

## Testing
- `pre-commit run --files Implementation\ Plan.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e139d6db0833191702ccf46ee742d