### PR TITLE
chore: convert asset keys to snake case

### DIFF
--- a/ProjectPlans/Asset Examples.md
+++ b/ProjectPlans/Asset Examples.md
@@ -48,14 +48,14 @@
         "filetype": "UNIDENTIFIED"
       }
     },
-    "Assets": {
-      "Assetname01": {
-        "Assettype": "Model",
-        "Assettags": [
+    "assets": {
+      "asset_name_01": {
+        "asset_type": "Model",
+        "asset_tags": [
           "Tag01",
           "Tag02"
         ],
-        "AssetContents": [
+        "asset_contents": [
           "01",
           "02",
           "04",


### PR DESCRIPTION
## Summary
- use snake case for asset keys in example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asset_organiser'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689e1be2863c8331b5c95fbeb7c36b58