### PR TITLE
Expand workspace and configuration editing UI

### DIFF
--- a/src/asset_organiser/ui/main_window.py
+++ b/src/asset_organiser/ui/main_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict
 
 from PySide6.QtWidgets import (
@@ -29,6 +30,13 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Asset Organiser")
         self._config = config
 
+        if self._config.library_config is None:
+            try:
+                root_dir = Path(__file__).resolve().parents[3]
+                self._config.set_library_path(root_dir)
+            except Exception:  # pragma: no cover - best effort
+                pass
+
         central = QWidget()
         layout = QHBoxLayout(central)
         self.sidebar = QListWidget()
@@ -39,7 +47,7 @@ class MainWindow(QMainWindow):
 
         # Views
         self.views: Dict[str, QWidget] = {
-            "Workspace": WorkspaceView(),
+            "Workspace": WorkspaceView(self._config),
             "Library": LibraryView(),
             "Settings": SettingsView(self._config),
         }

--- a/src/asset_organiser/ui/settings.py
+++ b/src/asset_organiser/ui/settings.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
-from PySide6.QtWidgets import (  # noqa: E501
+from typing import Dict
+
+from PySide6.QtWidgets import (
     QFormLayout,
+    QHBoxLayout,
+    QInputDialog,
     QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
     QPushButton,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
 
+from ..config_models import AssetTypeDefinition, FileTypeDefinition
 from ..config_service import ConfigService
 
 
-class SettingsView(QWidget):
-    """Settings editor connected to ConfigService."""
+class GeneralSettingsEditor(QWidget):
+    """Editor for general application settings."""
 
     def __init__(
         self,
@@ -48,3 +57,205 @@ class SettingsView(QWidget):
         settings.METADATA_FILENAME = self.metadata_name.text()
         self._config.settings = settings
         self._config.save_settings()
+
+
+class FileTypesEditor(QWidget):
+    """Master-detail editor for file type definitions."""
+
+    def __init__(
+        self,
+        config: ConfigService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self.file_types: Dict[str, FileTypeDefinition] = dict(
+            getattr(self._config.library_config, "FILE_TYPE_DEFINITIONS", {})
+        )
+
+        layout = QHBoxLayout(self)
+        left = QVBoxLayout()
+        self.list = QListWidget()
+        left.addWidget(self.list)
+        btn_row = QHBoxLayout()
+        self.add_btn = QPushButton("Add")
+        self.remove_btn = QPushButton("Remove")
+        btn_row.addWidget(self.add_btn)
+        btn_row.addWidget(self.remove_btn)
+        left.addLayout(btn_row)
+        layout.addLayout(left)
+
+        form = QFormLayout()
+        self.alias = QLineEdit()
+        self.color = QLineEdit()
+        self.hotkey = QLineEdit()
+        form.addRow("Alias", self.alias)
+        form.addRow("UI Color", self.color)
+        form.addRow("Hotkey", self.hotkey)
+        self.save_btn = QPushButton("Save")
+        form.addRow(self.save_btn)
+        layout.addLayout(form)
+
+        self.list.currentItemChanged.connect(self._load_current)
+        self.add_btn.clicked.connect(self._add)
+        self.remove_btn.clicked.connect(self._remove)
+        self.save_btn.clicked.connect(self._save_current)
+
+        for key in sorted(self.file_types.keys()):
+            self.list.addItem(key)
+
+    def _load_current(self) -> None:
+        item = self.list.currentItem()
+        if not item:
+            return
+        definition = self.file_types[item.text()]
+        self.alias.setText(definition.alias)
+        self.color.setText(definition.UI_color or "")
+        self.hotkey.setText(definition.UI_keybind or "")
+
+    def _save_current(self) -> None:
+        item = self.list.currentItem()
+        if not item:
+            return
+        key = item.text()
+        definition = self.file_types[key]
+        definition.alias = self.alias.text()
+        definition.UI_color = self.color.text() or None
+        definition.UI_keybind = self.hotkey.text() or None
+        self._config.library_config.FILE_TYPE_DEFINITIONS[key] = definition
+        self._config.save_library_config()
+
+    def _add(self) -> None:
+        text, ok = QInputDialog.getText(self, "New File Type", "ID")
+        if ok and text:
+            if text in self.file_types:
+                QMessageBox.warning(self, "Exists", "ID already exists")
+                return
+            definition = FileTypeDefinition(alias="")
+            self.file_types[text] = definition
+            self.list.addItem(text)
+            self.list.setCurrentRow(self.list.count() - 1)
+
+    def _remove(self) -> None:
+        item = self.list.currentItem()
+        if not item:
+            return
+        key = item.text()
+        del self.file_types[key]
+        self._config.library_config.FILE_TYPE_DEFINITIONS.pop(key, None)
+        row = self.list.row(item)
+        self.list.takeItem(row)
+        self._config.save_library_config()
+
+
+class AssetTypesEditor(QWidget):
+    """Editor for asset type definitions."""
+
+    def __init__(
+        self,
+        config: ConfigService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self.asset_types: Dict[str, AssetTypeDefinition] = dict(
+            getattr(self._config.library_config, "ASSET_TYPE_DEFINITIONS", {})
+        )
+
+        layout = QHBoxLayout(self)
+        left = QVBoxLayout()
+        self.list = QListWidget()
+        left.addWidget(self.list)
+        btn_row = QHBoxLayout()
+        self.add_btn = QPushButton("Add")
+        self.remove_btn = QPushButton("Remove")
+        btn_row.addWidget(self.add_btn)
+        btn_row.addWidget(self.remove_btn)
+        left.addLayout(btn_row)
+        layout.addLayout(left)
+
+        form = QFormLayout()
+        self.color = QLineEdit()
+        form.addRow("Color", self.color)
+        self.save_btn = QPushButton("Save")
+        form.addRow(self.save_btn)
+        layout.addLayout(form)
+
+        self.list.currentItemChanged.connect(self._load_current)
+        self.add_btn.clicked.connect(self._add)
+        self.remove_btn.clicked.connect(self._remove)
+        self.save_btn.clicked.connect(self._save_current)
+
+        for key in sorted(self.asset_types.keys()):
+            self.list.addItem(key)
+
+    def _load_current(self) -> None:
+        item = self.list.currentItem()
+        if not item:
+            return
+        definition = self.asset_types[item.text()]
+        self.color.setText(definition.color or "")
+
+    def _save_current(self) -> None:
+        item = self.list.currentItem()
+        if not item:
+            return
+        key = item.text()
+        definition = self.asset_types[key]
+        definition.color = self.color.text() or None
+        self._config.library_config.ASSET_TYPE_DEFINITIONS[key] = definition
+        self._config.save_library_config()
+
+    def _add(self) -> None:
+        text, ok = QInputDialog.getText(self, "New Asset Type", "ID")
+        if ok and text:
+            if text in self.asset_types:
+                QMessageBox.warning(self, "Exists", "ID already exists")
+                return
+            definition = AssetTypeDefinition()
+            self.asset_types[text] = definition
+            self.list.addItem(text)
+            self.list.setCurrentRow(self.list.count() - 1)
+
+    def _remove(self) -> None:
+        item = self.list.currentItem()
+        if not item:
+            return
+        key = item.text()
+        del self.asset_types[key]
+        self._config.library_config.ASSET_TYPE_DEFINITIONS.pop(key, None)
+        row = self.list.row(item)
+        self.list.takeItem(row)
+        self._config.save_library_config()
+
+
+class SettingsView(QWidget):
+    """Settings view with category navigation."""
+
+    def __init__(
+        self,
+        config: ConfigService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+
+        layout = QHBoxLayout(self)
+        self.categories = QListWidget()
+        self.stack = QStackedWidget()
+        layout.addWidget(self.categories)
+        layout.addWidget(self.stack, 1)
+
+        self.editors: Dict[str, QWidget] = {
+            "General": GeneralSettingsEditor(self._config),
+            "File Types": FileTypesEditor(self._config),
+            "Asset Types": AssetTypesEditor(self._config),
+        }
+
+        for name, editor in self.editors.items():
+            item = QListWidgetItem(name)
+            self.categories.addItem(item)
+            self.stack.addWidget(editor)
+
+        self.categories.currentRowChanged.connect(self.stack.setCurrentIndex)
+        self.categories.setCurrentRow(0)

--- a/src/asset_organiser/ui/workspace.py
+++ b/src/asset_organiser/ui/workspace.py
@@ -1,30 +1,89 @@
 from __future__ import annotations
 
+import zipfile
 from pathlib import Path
-from typing import Iterable
+from typing import Dict, Iterable, List
 
-from PySide6.QtWidgets import (  # noqa: E501
-    QLabel,
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QKeySequence, QShortcut
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFileDialog,
+    QHBoxLayout,
+    QPushButton,
     QTreeWidget,
     QTreeWidgetItem,
     QVBoxLayout,
     QWidget,
 )
 
+from ..config_models import AssetTypeDefinition, FileTypeDefinition
+from ..config_service import ConfigService
+
 
 class WorkspaceView(QWidget):
-    """Workspace view with drag-and-drop area and placeholder tree."""
+    """Workspace view showing sources, assets and files."""
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        config: ConfigService,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self.setAcceptDrops(True)
+        self._config = config
+
+        self.file_types: Dict[str, FileTypeDefinition] = dict(
+            getattr(self._config.library_config, "FILE_TYPE_DEFINITIONS", {})
+        )
+        self.asset_types: Dict[str, AssetTypeDefinition] = dict(
+            getattr(self._config.library_config, "ASSET_TYPE_DEFINITIONS", {})
+        )
+        # Ensure special types exist
+        self.file_types.setdefault(
+            "UNIDENTIFIED",
+            FileTypeDefinition(alias="UNID"),
+        )
 
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Drag files here"))
+        toolbar = QHBoxLayout()
+        self.add_btn = QPushButton("Add Source(s)")
+        self.remove_btn = QPushButton("Remove Selected")
+        self.classify_btn = QPushButton("Classify Selected")
+        self.process_btn = QPushButton("Process All")
+        for btn in [
+            self.add_btn,
+            self.remove_btn,
+            self.classify_btn,
+            self.process_btn,
+        ]:
+            toolbar.addWidget(btn)
+        toolbar.addStretch()
+        layout.addLayout(toolbar)
+
         self.tree = QTreeWidget()
-        self.tree.setHeaderLabels(["Source/Asset/File"])
+        self.tree.setHeaderLabels(["Name", "Type"])
         layout.addWidget(self.tree, 1)
 
+        self._register_hotkeys()
+
+        self.add_btn.clicked.connect(self._add_sources_dialog)
+        self.remove_btn.clicked.connect(self.remove_selected)
+
+    # ------------------------------------------------------------------
+    def _register_hotkeys(self) -> None:
+        self._shortcuts: List[QShortcut] = []
+        for ft_id, definition in self.file_types.items():
+            key = definition.UI_keybind
+            if not key:
+                continue
+            sc = QShortcut(QKeySequence(key), self)
+            sc.activated.connect(
+                lambda ft_id=ft_id: self.assign_filetype_to_selection(ft_id)
+            )
+            self._shortcuts.append(sc)
+
+    # ------------------------------------------------------------------
     # Drag-and-drop events
     def dragEnterEvent(self, event) -> None:  # type: ignore[override]
         if event.mimeData().hasUrls():
@@ -35,8 +94,96 @@ class WorkspaceView(QWidget):
         self.add_paths(paths)
         event.acceptProposedAction()
 
-    # Helper for tests
+    # ------------------------------------------------------------------
+    def _collect_files(self, path: Path) -> List[Path]:
+        if path.is_dir():
+            return [p for p in path.rglob("*") if p.is_file()]
+        if zipfile.is_zipfile(path):
+            with zipfile.ZipFile(path) as zf:
+                return [Path(f) for f in zf.namelist() if not f.endswith("/")]
+        return [path]
+
+    def _group_files(self, files: Iterable[Path]) -> Dict[str, List[Path]]:
+        assets: Dict[str, List[Path]] = {}
+        for file in files:
+            stem = file.stem
+            asset_name = stem.split("_")[0] if "_" in stem else stem
+            assets.setdefault(asset_name, []).append(file)
+        return assets
+
+    def _default_asset_type(self) -> str:
+        return self._config.settings.DEFAULT_ASSET_TYPE or next(
+            iter(self.asset_types.keys()), ""
+        )
+
+    # ------------------------------------------------------------------
     def add_paths(self, paths: Iterable[Path]) -> None:
         for path in paths:
-            item = QTreeWidgetItem([path.name])
-            self.tree.addTopLevelItem(item)
+            source_item = QTreeWidgetItem([path.name, ""])
+            source_item.setData(0, Qt.UserRole, "source")
+            self.tree.addTopLevelItem(source_item)
+            files = self._collect_files(path)
+            assets = self._group_files(files)
+            for asset_name, asset_files in assets.items():
+                asset_item = QTreeWidgetItem(
+                    [f"Asset: {asset_name}", self._default_asset_type()]
+                )
+                asset_item.setData(0, Qt.UserRole, "asset")
+                source_item.addChild(asset_item)
+                combo = QComboBox()
+                combo.addItems(sorted(self.asset_types.keys()))
+                combo.setCurrentText(self._default_asset_type())
+                combo.currentTextChanged.connect(
+                    lambda text, item=asset_item: item.setText(1, text)
+                )
+                self.tree.setItemWidget(asset_item, 1, combo)
+                for file_path in asset_files:
+                    file_item = QTreeWidgetItem(
+                        [file_path.name, "UNIDENTIFIED"],
+                    )
+                    file_item.setData(0, Qt.UserRole, "file")
+                    asset_item.addChild(file_item)
+                    combo_f = QComboBox()
+                    combo_f.addItems(sorted(self.file_types.keys()))
+                    combo_f.setCurrentText("UNIDENTIFIED")
+                    combo_f.currentTextChanged.connect(
+                        lambda text, item=file_item: self._set_file_type(
+                            item,
+                            text,
+                        ),
+                    )
+                    self.tree.setItemWidget(file_item, 1, combo_f)
+
+    # ------------------------------------------------------------------
+    def _set_file_type(self, item: QTreeWidgetItem, file_type: str) -> None:
+        item.setText(1, file_type)
+        definition = self.file_types.get(file_type)
+        if definition and definition.UI_color:
+            color = QColor(definition.UI_color)
+            item.setForeground(0, color)
+            item.setForeground(1, color)
+
+    def assign_filetype_to_selection(self, file_type: str) -> None:
+        for item in self.tree.selectedItems():
+            if item.data(0, Qt.UserRole) == "file":
+                combo = self.tree.itemWidget(item, 1)
+                if isinstance(combo, QComboBox):
+                    combo.setCurrentText(file_type)
+                else:
+                    self._set_file_type(item, file_type)
+
+    # ------------------------------------------------------------------
+    def remove_selected(self) -> None:
+        for item in self.tree.selectedItems():
+            parent = item.parent()
+            if parent is None:
+                index = self.tree.indexOfTopLevelItem(item)
+                self.tree.takeTopLevelItem(index)
+            else:
+                parent.removeChild(item)
+
+    # ------------------------------------------------------------------
+    def _add_sources_dialog(self) -> None:
+        files, _ = QFileDialog.getOpenFileNames(self, "Add Sources")
+        if files:
+            self.add_paths(Path(f) for f in files)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
 
+import asset_organiser.config_models as cm
 from asset_organiser import ConfigService
 from asset_organiser.ui import MainWindow, WorkspaceView
 
@@ -16,6 +17,7 @@ def test_main_window_loads_and_saves_settings(tmp_path: Path) -> None:
 
     cfg_path = tmp_path / "settings.json"
     service = ConfigService(app_config_path=cfg_path)
+    service.set_library_path(tmp_path)
     window = MainWindow(service)
 
     # Sidebar has expected tabs
@@ -26,8 +28,9 @@ def test_main_window_loads_and_saves_settings(tmp_path: Path) -> None:
     # Switch to settings view and modify value
     window.sidebar.setCurrentRow(2)
     settings_view = window.views["Settings"]
-    settings_view.output_dir.setText("/tmp")
-    QTest.mouseClick(settings_view.save_btn, Qt.LeftButton)
+    general = settings_view.editors["General"]
+    general.output_dir.setText("/tmp")
+    QTest.mouseClick(general.save_btn, Qt.LeftButton)
 
     assert service.settings.OUTPUT_BASE_DIR == "/tmp"
 
@@ -35,13 +38,27 @@ def test_main_window_loads_and_saves_settings(tmp_path: Path) -> None:
     app.quit()
 
 
-def test_workspace_adds_items(tmp_path: Path) -> None:
+def test_workspace_adds_items_and_hotkey(tmp_path: Path) -> None:
     app = QApplication.instance() or QApplication([])
-    view = WorkspaceView()
+    service = ConfigService(app_config_path=tmp_path / "settings.json")
+    service.set_library_path(tmp_path)
+    service.library_config.FILE_TYPE_DEFINITIONS = {
+        "MAP_COL": cm.FileTypeDefinition(alias="COL", UI_keybind="C"),
+    }
+    service.library_config.ASSET_TYPE_DEFINITIONS = {
+        "Surface": cm.AssetTypeDefinition(),
+    }
+    service.save_library_config()
+
+    view = WorkspaceView(service)
     file_path = tmp_path / "file.txt"
     file_path.write_text("x")
     view.add_paths([file_path])
     assert view.tree.topLevelItemCount() == 1
-    assert view.tree.topLevelItem(0).text(0) == "file.txt"
+    asset_item = view.tree.topLevelItem(0).child(0)
+    file_item = asset_item.child(0)
+    view.tree.setCurrentItem(file_item)
+    QTest.keyClick(view, Qt.Key_C)
+    assert file_item.text(1) == "MAP_COL"
     view.deleteLater()
     app.quit()


### PR DESCRIPTION
## Summary
- flesh out workspace tree with toolbar, archive parsing and hotkey file-type assignment
- add configurable editors for general, file-type and asset-type settings
- load library configuration into main window and workspace

## Testing
- `pre-commit run --files src/asset_organiser/ui/main_window.py src/asset_organiser/ui/settings.py src/asset_organiser/ui/workspace.py tests/test_ui.py`
- `PYTHONPATH=src pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689e221873308331aadf623ca18c5ec2