### PR TITLE
Add classification service and tests

### DIFF
--- a/src/asset_organiser/classification/__init__.py
+++ b/src/asset_organiser/classification/__init__.py
@@ -4,10 +4,12 @@ from .models import ClassificationState
 from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
+from .service import ClassificationService
 
 __all__ = [
     "ClassificationState",
     "ClassificationModule",
     "ClassificationPipeline",
     "RuleBasedFileTypeModule",
+    "ClassificationService",
 ]

--- a/src/asset_organiser/classification/service.py
+++ b/src/asset_organiser/classification/service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..config_service import ConfigService
+from .models import ClassificationState
+from .module import ClassificationModule
+from .pipeline import ClassificationPipeline
+from .rule_based import RuleBasedFileTypeModule
+
+
+class _LLMPlaceholderModule(ClassificationModule):
+    """Placeholder for a future LLM-based classification module."""
+
+    def __init__(self, name: str = "LLMModule") -> None:
+        super().__init__(name)
+
+    def run(self, state: ClassificationState) -> ClassificationState:
+        return state
+
+
+class ClassificationService:
+    """High level service for executing classification pipelines."""
+
+    def __init__(self, config_service: ConfigService) -> None:
+        if config_service.library_config is None:
+            raise RuntimeError("Library configuration not loaded")
+        classification = config_service.library_config.CLASSIFICATION
+        self.keyword_rules = classification.keyword_rules
+        # ``rule_keywords`` may not be present in older configs
+        self.rule_keywords = getattr(classification, "rule_keywords", {})
+
+        self.pipeline = ClassificationPipeline()
+        rule_module = RuleBasedFileTypeModule(self.keyword_rules)
+        self.pipeline.add_module(rule_module)
+        self.pipeline.add_module(
+            _LLMPlaceholderModule(),
+            after=[rule_module.name],
+        )
+
+    # ------------------------------------------------------------------
+    def classify(self, state: ClassificationState) -> ClassificationState:
+        """Run the configured pipeline on ``state``."""
+        return self.pipeline.run(state)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def from_file_list(files: Iterable[str]) -> ClassificationState:
+        """Create a :class:`ClassificationState` from a list of filenames."""
+        contents = {str(i): {"filename": f} for i, f in enumerate(files)}
+        data = {"sources": {"src": {"metadata": {}, "contents": contents}}}
+        return ClassificationState.model_validate(data)

--- a/tests/test_classification_service.py
+++ b/tests/test_classification_service.py
@@ -1,0 +1,32 @@
+from asset_organiser.classification import ClassificationState
+from asset_organiser.classification.service import ClassificationService
+from asset_organiser.config_models import ClassificationSettings, LibraryConfig
+from asset_organiser.config_service import ConfigService
+
+
+def _make_service() -> ClassificationService:
+    cfg_service = ConfigService()
+    cfg_service.library_config = LibraryConfig(
+        CLASSIFICATION=ClassificationSettings(
+            keyword_rules={"_col": "MAP_COL"},
+            rule_keywords={"dummy": ["keyword"]},
+        )
+    )
+    return ClassificationService(cfg_service)
+
+
+def test_service_builds_pipeline_and_classifies() -> None:
+    service = _make_service()
+    state = ClassificationService.from_file_list(["wood_col.png", "other.txt"])
+    result = service.classify(state)
+    contents = result.sources["src"].contents
+    assert contents["0"].filetype == "MAP_COL"
+    assert contents["1"].filetype is None
+    assert "LLMModule" in service.pipeline._modules
+
+
+def test_from_file_list_json_roundtrip() -> None:
+    state = ClassificationService.from_file_list(["a.txt"])
+    text = state.to_json()
+    loaded = ClassificationState.from_json(text)
+    assert loaded.sources["src"].contents["0"].filename == "a.txt"


### PR DESCRIPTION
## Summary
- add `ClassificationService` to build and run classification pipelines using config-driven rules
- expose helper to create classification state from file lists and JSON round-trips
- test service pipeline construction and JSON roundtrip

## Testing
- `pre-commit run --files src/asset_organiser/classification/__init__.py src/asset_organiser/classification/service.py tests/test_classification_service.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4ed45b2c83318f1c3f89142f464c