### PR TITLE
Enable branching in classification pipeline

### DIFF
--- a/src/asset_organiser/classification/module.py
+++ b/src/asset_organiser/classification/module.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import List, Tuple
 
 from .models import ClassificationState
 
@@ -14,6 +15,13 @@ class ClassificationModule(ABC):
         self.name = name or self.__class__.__name__
 
     @abstractmethod
-    def run(self, state: ClassificationState) -> ClassificationState:
-        """Process and return modified classification state."""
+    def run(
+        self, state: ClassificationState
+    ) -> ClassificationState | Tuple[ClassificationState, List[str]]:
+        """Process and return modified classification state.
+
+        Modules may optionally return a tuple of ``(state, [next_module_names])``
+        to explicitly route execution to downstream modules.  If only the state
+        is returned, the pipeline will follow the predefined DAG edges.
+        """
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- allow classification modules to return downstream module names for routing
- queue modules based on runtime routing results to support DAG branching
- add tests covering split routing for identified vs unidentified files

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f50bd86cc833194c8da35290170e4