### PR TITLE
Add constant and keyword-based file type classification modules

### DIFF
--- a/src/asset_organiser/classification/__init__.py
+++ b/src/asset_organiser/classification/__init__.py
@@ -1,5 +1,6 @@
 """Classification service module framework."""
 
+from .constants import AssignConstantsModule
 from .models import ClassificationState
 from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
@@ -11,5 +12,6 @@ __all__ = [
     "ClassificationModule",
     "ClassificationPipeline",
     "RuleBasedFileTypeModule",
+    "AssignConstantsModule",
     "ClassificationService",
 ]

--- a/src/asset_organiser/classification/constants.py
+++ b/src/asset_organiser/classification/constants.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .models import ClassificationState
+from .module import ClassificationModule
+
+# Default mapping of file extensions or substrings to file types.  This can be
+# overridden by providing a custom mapping when instantiating the module.
+DEFAULT_CONSTANTS: Dict[str, str] = {
+    ".fbx": "FILE_MODEL",
+    ".obj": "FILE_MODEL",
+    ".sbsar": "FILE_SBSAR",
+}
+
+
+class AssignConstantsModule(ClassificationModule):
+    """Assign file types based on constant filename patterns or extensions."""
+
+    def __init__(self, constants: Dict[str, str] | None = None) -> None:
+        super().__init__()
+        constants = constants or DEFAULT_CONSTANTS
+        # Normalise patterns for case-insensitive comparison
+        self.constants = {k.lower(): v for k, v in constants.items()}
+
+    def run(self, state: ClassificationState) -> ClassificationState:
+        for source in state.sources.values():
+            for entry in source.contents.values():
+                if entry.filetype:
+                    continue
+                name = entry.filename.lower()
+                for pattern, filetype in self.constants.items():
+                    if name.endswith(pattern) or pattern in name:
+                        entry.filetype = filetype
+                        break
+        return state

--- a/src/asset_organiser/classification/rule_based.py
+++ b/src/asset_organiser/classification/rule_based.py
@@ -2,16 +2,23 @@ from __future__ import annotations
 
 from typing import Dict
 
+from ..config_models import FileTypeDefinition
 from .models import ClassificationState
 from .module import ClassificationModule
 
+FileTypeDefs = Dict[str, FileTypeDefinition]
+
 
 class RuleBasedFileTypeModule(ClassificationModule):
-    """Assign filetypes based on keyword rules from configuration."""
+    """Assign filetypes based on ``rule_keywords`` in configuration."""
 
-    def __init__(self, keyword_rules: Dict[str, str]) -> None:
+    def __init__(self, filetype_definitions: FileTypeDefs) -> None:
         super().__init__()
-        self.keyword_rules = {k.lower(): v for k, v in keyword_rules.items()}
+        keyword_rules: Dict[str, str] = {}
+        for filetype, definition in filetype_definitions.items():
+            for keyword in definition.rule_keywords:
+                keyword_rules[keyword.lower()] = filetype
+        self.keyword_rules = keyword_rules
 
     def run(self, state: ClassificationState) -> ClassificationState:
         for source in state.sources.values():

--- a/tests/test_classification_service.py
+++ b/tests/test_classification_service.py
@@ -1,27 +1,36 @@
 from asset_organiser.classification import ClassificationState
 from asset_organiser.classification.service import ClassificationService
-from asset_organiser.config_models import ClassificationSettings, LibraryConfig
+from asset_organiser.config_models import (
+    ClassificationSettings,
+    FileTypeDefinition,
+    LibraryConfig,
+)
 from asset_organiser.config_service import ConfigService
 
 
 def _make_service() -> ClassificationService:
     cfg_service = ConfigService()
     cfg_service.library_config = LibraryConfig(
+        FILE_TYPE_DEFINITIONS={
+            "MAP_COL": FileTypeDefinition(alias="COL", rule_keywords=["_col"])
+        },
         CLASSIFICATION=ClassificationSettings(
-            keyword_rules={"_col": "MAP_COL"},
-            rule_keywords={"dummy": ["keyword"]},
-        )
+            keyword_rules={"readme": "IGNORE"},
+        ),
     )
     return ClassificationService(cfg_service)
 
 
 def test_service_builds_pipeline_and_classifies() -> None:
     service = _make_service()
-    state = ClassificationService.from_file_list(["wood_col.png", "other.txt"])
+    state = ClassificationService.from_file_list(
+        ["wood_col.png", "readme.txt", "other.txt"]
+    )
     result = service.classify(state)
     contents = result.sources["src"].contents
     assert contents["0"].filetype == "MAP_COL"
-    assert contents["1"].filetype is None
+    assert contents["1"].filetype == "IGNORE"
+    assert contents["2"].filetype is None
     assert "LLMModule" in service.pipeline._modules
 
 


### PR DESCRIPTION
## Summary
- add `AssignConstantsModule` for mapping filename patterns to file types
- derive keyword rules from `FileTypeDefinition` entries
- register constant and rule-based modules before LLM placeholder

## Testing
- `pre-commit run --files src/asset_organiser/classification/__init__.py src/asset_organiser/classification/constants.py src/asset_organiser/classification/rule_based.py src/asset_organiser/classification/service.py tests/test_classification_pipeline.py tests/test_classification_service.py`
- `PYTHONPATH=src pytest tests/test_classification_pipeline.py tests/test_classification_service.py tests/test_config_service.py tests/test_package_import.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'asset_organiser'; ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f53a1caa48331977b10f63289dadf