### PR TITLE
Add LLM filetype classifier with pluggable client and routing logic

### DIFF
--- a/src/asset_organiser/classification/__init__.py
+++ b/src/asset_organiser/classification/__init__.py
@@ -4,6 +4,7 @@ from .models import ClassificationState
 from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
+from .llm_filetypes import LLMFiletypeModule
 from .service import ClassificationService
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "ClassificationModule",
     "ClassificationPipeline",
     "RuleBasedFileTypeModule",
+    "LLMFiletypeModule",
     "ClassificationService",
 ]

--- a/src/asset_organiser/classification/llm_filetypes.py
+++ b/src/asset_organiser/classification/llm_filetypes.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""LLM-assisted filetype classification module."""
+
+from typing import Protocol
+
+from .models import ClassificationState
+from .module import ClassificationModule
+
+
+class LLMClient(Protocol):
+    """Protocol for pluggable LLM clients."""
+
+    def classify_filetype(self, filename: str, prompt: str | None = None) -> str | None:
+        """Return a predicted filetype for ``filename``."""
+        ...
+
+
+class LLMFiletypeModule(ClassificationModule):
+    """Classify filetypes using an LLM client for remaining files."""
+
+    def __init__(self, client: LLMClient, prompt: str | None = None) -> None:
+        super().__init__()
+        self.client = client
+        self.prompt = prompt
+
+    def run(self, state: ClassificationState) -> ClassificationState:
+        for source in state.sources.values():
+            for entry in source.contents.values():
+                if entry.filetype:
+                    continue
+                result = self.client.classify_filetype(entry.filename, self.prompt)
+                if result:
+                    entry.filetype = result
+        return state

--- a/src/asset_organiser/classification/rule_based.py
+++ b/src/asset_organiser/classification/rule_based.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List, Tuple
 
 from .models import ClassificationState
 from .module import ClassificationModule
@@ -9,11 +9,14 @@ from .module import ClassificationModule
 class RuleBasedFileTypeModule(ClassificationModule):
     """Assign filetypes based on keyword rules from configuration."""
 
-    def __init__(self, keyword_rules: Dict[str, str]) -> None:
+    def __init__(self, keyword_rules: Dict[str, str], next_module: str | None = None) -> None:
         super().__init__()
         self.keyword_rules = {k.lower(): v for k, v in keyword_rules.items()}
+        self._next_module = next_module
 
-    def run(self, state: ClassificationState) -> ClassificationState:
+    def run(
+        self, state: ClassificationState
+    ) -> ClassificationState | Tuple[ClassificationState, List[str]]:
         for source in state.sources.values():
             for entry in source.contents.values():
                 if entry.filetype:
@@ -23,4 +26,14 @@ class RuleBasedFileTypeModule(ClassificationModule):
                     if keyword in name:
                         entry.filetype = filetype
                         break
+
+        if self._next_module is not None:
+            has_unclassified = any(
+                entry.filetype is None
+                for source in state.sources.values()
+                for entry in source.contents.values()
+            )
+            next_mods = [self._next_module] if has_unclassified else []
+            return state, next_mods
+
         return state

--- a/src/asset_organiser/classification/service.py
+++ b/src/asset_organiser/classification/service.py
@@ -4,25 +4,24 @@ from typing import Iterable
 
 from ..config_service import ConfigService
 from .models import ClassificationState
-from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
+from .llm_filetypes import LLMFiletypeModule, LLMClient
 
 
-class _LLMPlaceholderModule(ClassificationModule):
-    """Placeholder for a future LLM-based classification module."""
+class _DummyLLMClient:
+    """Fallback LLM client that performs no classification."""
 
-    def __init__(self, name: str = "LLMModule") -> None:
-        super().__init__(name)
-
-    def run(self, state: ClassificationState) -> ClassificationState:
-        return state
+    def classify_filetype(self, filename: str, prompt: str | None = None) -> str | None:
+        return None
 
 
 class ClassificationService:
     """High level service for executing classification pipelines."""
 
-    def __init__(self, config_service: ConfigService) -> None:
+    def __init__(
+        self, config_service: ConfigService, llm_client: LLMClient | None = None
+    ) -> None:
         if config_service.library_config is None:
             raise RuntimeError("Library configuration not loaded")
         classification = config_service.library_config.CLASSIFICATION
@@ -30,13 +29,15 @@ class ClassificationService:
         # ``rule_keywords`` may not be present in older configs
         self.rule_keywords = getattr(classification, "rule_keywords", {})
 
-        self.pipeline = ClassificationPipeline()
-        rule_module = RuleBasedFileTypeModule(self.keyword_rules)
-        self.pipeline.add_module(rule_module)
-        self.pipeline.add_module(
-            _LLMPlaceholderModule(),
-            after=[rule_module.name],
+        client = llm_client or _DummyLLMClient()
+        llm_module = LLMFiletypeModule(client, classification.llm_prompt)
+        rule_module = RuleBasedFileTypeModule(
+            self.keyword_rules, next_module=llm_module.name
         )
+
+        self.pipeline = ClassificationPipeline()
+        self.pipeline.add_module(rule_module)
+        self.pipeline.add_module(llm_module, after=[rule_module.name])
 
     # ------------------------------------------------------------------
     def classify(self, state: ClassificationState) -> ClassificationState:

--- a/src/asset_organiser/config_models.py
+++ b/src/asset_organiser/config_models.py
@@ -60,11 +60,12 @@ class LLMProviderProfile(BaseModel):
 
 
 class ClassificationSettings(BaseModel):
+    llm_provider: Optional[str] = Field(None, alias="LLM Provider")
+    llm_prompt: Optional[str] = Field(None, alias="LLM Prompt")
     providers: List[LLMProviderProfile] = Field(
         default_factory=list,
         alias="Providers",
     )
-    llm_prompt: Optional[str] = Field(None, alias="LLM Prompts")
     keyword_rules: Dict[str, str] = Field(
         default_factory=dict,
         alias="Keyword Rules",


### PR DESCRIPTION
## Summary
- add `LLMFiletypeModule` powered by pluggable LLM clients
- expose LLM provider and prompt in classification settings
- wire LLM module into classification pipeline after rule-based module with routing for unclassified files
- tests for new classification workflow

## Testing
- `PYTHONPATH=src pytest tests/test_classification_pipeline.py tests/test_classification_service.py tests/test_config_service.py -q`
- `PYTHONPATH=src pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689f53b07f7083319b4ca917341261a7