### PR TITLE
Add pluggable LLM filetype classification module

### DIFF
--- a/src/asset_organiser/classification/__init__.py
+++ b/src/asset_organiser/classification/__init__.py
@@ -6,12 +6,14 @@ from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
 from .service import ClassificationService
+from .llm_filetypes import LLMFiletypeModule
 
 __all__ = [
     "ClassificationState",
     "ClassificationModule",
     "ClassificationPipeline",
     "RuleBasedFileTypeModule",
+    "LLMFiletypeModule",
     "AssignConstantsModule",
     "ClassificationService",
 ]

--- a/src/asset_organiser/classification/llm_filetypes.py
+++ b/src/asset_organiser/classification/llm_filetypes.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import ClassificationState
+from .module import ClassificationModule
+
+
+class LLMClient(Protocol):
+    """Protocol for LLM clients used by :class:`LLMFiletypeModule`."""
+
+    def complete(self, prompt: str) -> str:
+        """Return the model's textual completion for ``prompt``."""
+
+
+class NoOpLLMClient:
+    """Fallback LLM client that performs no classification."""
+
+    def complete(self, prompt: str) -> str:  # pragma: no cover - trivial
+        return ""
+
+
+class LLMFiletypeModule(ClassificationModule):
+    """Classify filetypes using a language model."""
+
+    def __init__(self, client: LLMClient, prompt: str) -> None:
+        super().__init__()
+        self.client = client
+        self.prompt = prompt
+
+    def run(self, state: ClassificationState) -> ClassificationState:
+        for source in state.sources.values():
+            for entry in source.contents.values():
+                if entry.filetype:
+                    continue
+                full_prompt = f"{self.prompt}\nFilename: {entry.filename}"
+                result = self.client.complete(full_prompt).strip()
+                if result:
+                    entry.filetype = result
+        return state
+

--- a/src/asset_organiser/classification/rule_based.py
+++ b/src/asset_organiser/classification/rule_based.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 
 from ..config_models import FileTypeDefinition
 from .models import ClassificationState
@@ -12,22 +12,32 @@ FileTypeDefs = Dict[str, FileTypeDefinition]
 class RuleBasedFileTypeModule(ClassificationModule):
     """Assign filetypes based on ``rule_keywords`` in configuration."""
 
-    def __init__(self, filetype_definitions: FileTypeDefs) -> None:
+    def __init__(self, filetype_definitions: FileTypeDefs, *, next_module: str | None = None) -> None:
         super().__init__()
         keyword_rules: Dict[str, str] = {}
         for filetype, definition in filetype_definitions.items():
             for keyword in definition.rule_keywords:
                 keyword_rules[keyword.lower()] = filetype
         self.keyword_rules = keyword_rules
+        self._next_module = next_module
 
-    def run(self, state: ClassificationState) -> ClassificationState:
+    def run(
+        self, state: ClassificationState
+    ) -> ClassificationState | tuple[ClassificationState, List[str]]:
+        route = False
         for source in state.sources.values():
             for entry in source.contents.values():
                 if entry.filetype:
                     continue
                 name = entry.filename.lower()
+                matched = False
                 for keyword, filetype in self.keyword_rules.items():
                     if keyword in name:
                         entry.filetype = filetype
+                        matched = True
                         break
+                if not matched:
+                    route = True
+        if self._next_module and route:
+            return state, [self._next_module]
         return state

--- a/src/asset_organiser/classification/service.py
+++ b/src/asset_organiser/classification/service.py
@@ -5,40 +5,34 @@ from typing import Iterable
 from ..config_service import ConfigService
 from .constants import AssignConstantsModule
 from .models import ClassificationState
-from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
-
-
-class _LLMPlaceholderModule(ClassificationModule):
-    """Placeholder for a future LLM-based classification module."""
-
-    def __init__(self, name: str = "LLMModule") -> None:
-        super().__init__(name)
-
-    def run(self, state: ClassificationState) -> ClassificationState:
-        return state
+from .llm_filetypes import LLMClient, LLMFiletypeModule, NoOpLLMClient
 
 
 class ClassificationService:
     """High level service for executing classification pipelines."""
 
-    def __init__(self, config_service: ConfigService) -> None:
+    def __init__(self, config_service: ConfigService, llm_client: LLMClient | None = None) -> None:
         if config_service.library_config is None:
             raise RuntimeError("Library configuration not loaded")
         classification = config_service.library_config.CLASSIFICATION
         filetype_defs = config_service.library_config.FILE_TYPE_DEFINITIONS
         self.keyword_rules = classification.keyword_rules
 
+        if llm_client is None:
+            llm_client = NoOpLLMClient()
+
         self.pipeline = ClassificationPipeline()
         const_module = AssignConstantsModule(self.keyword_rules)
         self.pipeline.add_module(const_module)
-        rule_module = RuleBasedFileTypeModule(filetype_defs)
-        self.pipeline.add_module(rule_module, after=[const_module.name])
-        self.pipeline.add_module(
-            _LLMPlaceholderModule(),
-            after=[rule_module.name],
+
+        llm_module = LLMFiletypeModule(llm_client, classification.prompt)
+        rule_module = RuleBasedFileTypeModule(
+            filetype_defs, next_module=llm_module.name
         )
+        self.pipeline.add_module(rule_module, after=[const_module.name])
+        self.pipeline.add_module(llm_module, after=[rule_module.name])
 
     # ------------------------------------------------------------------
     def classify(self, state: ClassificationState) -> ClassificationState:

--- a/src/asset_organiser/config_models.py
+++ b/src/asset_organiser/config_models.py
@@ -60,11 +60,12 @@ class LLMProviderProfile(BaseModel):
 
 
 class ClassificationSettings(BaseModel):
+    provider: Optional[str] = Field(None, alias="LLM Provider")
+    prompt: str = Field("", alias="LLM Prompt")
     providers: List[LLMProviderProfile] = Field(
         default_factory=list,
         alias="Providers",
     )
-    llm_prompt: Optional[str] = Field(None, alias="LLM Prompts")
     keyword_rules: Dict[str, str] = Field(
         default_factory=dict,
         alias="Keyword Rules",


### PR DESCRIPTION
## Summary
- add LLMFiletypeModule using pluggable LLM client and NoOp fallback
- expose LLM provider selection and prompt in ClassificationSettings
- route unclassified files from rule-based module to LLM module in ClassificationService

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f5b68b4748331bde19785a6a6c948