### PR TITLE
Add standalone separation and grouping modules to classification pipeline

### DIFF
--- a/src/asset_organiser/classification/__init__.py
+++ b/src/asset_organiser/classification/__init__.py
@@ -1,12 +1,14 @@
 """Classification service module framework."""
 
 from .constants import AssignConstantsModule
+from .llm_filetypes import LLMFiletypeModule
+from .llm_grouping import LLMGroupFilesModule
 from .models import ClassificationState
 from .module import ClassificationModule
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
 from .service import ClassificationService
-from .llm_filetypes import LLMFiletypeModule
+from .standalone import SeparateStandaloneModule
 
 __all__ = [
     "ClassificationState",
@@ -16,4 +18,6 @@ __all__ = [
     "LLMFiletypeModule",
     "AssignConstantsModule",
     "ClassificationService",
+    "SeparateStandaloneModule",
+    "LLMGroupFilesModule",
 ]

--- a/src/asset_organiser/classification/llm_grouping.py
+++ b/src/asset_organiser/classification/llm_grouping.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from .llm_filetypes import LLMClient, NoOpLLMClient
+from .models import AssetEntry, ClassificationState
+from .module import ClassificationModule
+
+
+class LLMGroupFilesModule(ClassificationModule):
+    """Group unassigned files into assets based on filename patterns.
+
+    This module is a lightweight stand-in for an LLM powered grouping system.
+    It analyses remaining files (those not already referenced by an asset) and
+    groups them by a simple heuristic: files sharing the same directory and the
+    same prefix before the first underscore are considered part of the same
+    asset.  The heuristic keeps the implementation deterministic for testing
+    while exposing a hook for future LLM assistance via ``LLMClient``.
+    """
+
+    def __init__(self, client: LLMClient | None = None) -> None:
+        super().__init__()
+        self.client = client or NoOpLLMClient()
+
+    # ------------------------------------------------------------------
+    def _new_asset_id(self, existing: Dict[str, AssetEntry]) -> str:
+        i = 0
+        while str(i) in existing:
+            i += 1
+        return str(i)
+
+    # ------------------------------------------------------------------
+    def run(self, state: ClassificationState) -> ClassificationState:
+        for source in state.sources.values():
+            assigned = {
+                file_id
+                for asset in source.assets.values()
+                for file_id in asset.asset_contents
+            }
+            groups: Dict[str, str] = {}
+            for file_id, entry in source.contents.items():
+                if file_id in assigned:
+                    continue
+                path = Path(entry.filename)
+                prefix = path.stem.split("_")[0]
+                key = str(path.parent / prefix)
+                if key not in groups:
+                    asset_id = self._new_asset_id(source.assets)
+                    groups[key] = asset_id
+                    source.assets[asset_id] = AssetEntry(asset_contents=[])
+                asset_id = groups[key]
+                source.assets[asset_id].asset_contents.append(file_id)
+        return state

--- a/src/asset_organiser/classification/service.py
+++ b/src/asset_organiser/classification/service.py
@@ -4,16 +4,22 @@ from typing import Iterable
 
 from ..config_service import ConfigService
 from .constants import AssignConstantsModule
+from .llm_filetypes import LLMClient, LLMFiletypeModule, NoOpLLMClient
+from .llm_grouping import LLMGroupFilesModule
 from .models import ClassificationState
 from .pipeline import ClassificationPipeline
 from .rule_based import RuleBasedFileTypeModule
-from .llm_filetypes import LLMClient, LLMFiletypeModule, NoOpLLMClient
+from .standalone import SeparateStandaloneModule
 
 
 class ClassificationService:
     """High level service for executing classification pipelines."""
 
-    def __init__(self, config_service: ConfigService, llm_client: LLMClient | None = None) -> None:
+    def __init__(
+        self,
+        config_service: ConfigService,
+        llm_client: LLMClient | None = None,
+    ) -> None:
         if config_service.library_config is None:
             raise RuntimeError("Library configuration not loaded")
         classification = config_service.library_config.CLASSIFICATION
@@ -33,6 +39,14 @@ class ClassificationService:
         )
         self.pipeline.add_module(rule_module, after=[const_module.name])
         self.pipeline.add_module(llm_module, after=[rule_module.name])
+
+        # Phase 2: asset grouping
+        group_module = LLMGroupFilesModule(llm_client)
+        separate_module = SeparateStandaloneModule(
+            filetype_defs, grouping_next=group_module.name
+        )
+        self.pipeline.add_module(separate_module, after=[llm_module.name])
+        self.pipeline.add_module(group_module, after=[separate_module.name])
 
     # ------------------------------------------------------------------
     def classify(self, state: ClassificationState) -> ClassificationState:

--- a/src/asset_organiser/classification/standalone.py
+++ b/src/asset_organiser/classification/standalone.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..config_models import FileTypeDefinition
+from .models import AssetEntry, ClassificationState
+from .module import ClassificationModule
+
+
+class SeparateStandaloneModule(ClassificationModule):
+    """Move standalone files into individual asset entries.
+
+    The module inspects each file's assigned ``filetype`` and consults the
+    provided ``FileTypeDefinition`` mapping.  If a file type is marked with
+    ``is_standalone=True`` it is considered a complete asset on its own.  The
+    file is therefore placed into a newly created :class:`AssetEntry` with no
+    other files.  Remaining files are left untouched for further grouping.
+
+    The module can optionally route execution to downstream modules.  When
+    ``standalone_next`` or ``grouping_next`` are supplied, the module will
+    return ``(state, next_modules)`` directing the pipeline accordingly.  This
+    mirrors the behaviour of :class:`RuleBasedFileTypeModule` and allows
+    conditional execution of later stages in the pipeline.
+    """
+
+    def __init__(
+        self,
+        filetype_definitions: Dict[str, FileTypeDefinition],
+        *,
+        standalone_next: str | None = None,
+        grouping_next: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.filetype_definitions = filetype_definitions
+        self._standalone_next = standalone_next
+        self._grouping_next = grouping_next
+
+    # ------------------------------------------------------------------
+    def _new_asset_id(self, source) -> str:
+        existing = set(source.assets.keys())
+        i = 0
+        while str(i) in existing:
+            i += 1
+        return str(i)
+
+    # ------------------------------------------------------------------
+    def run(
+        self, state: ClassificationState
+    ) -> ClassificationState | tuple[ClassificationState, List[str]]:
+        has_standalone = False
+        has_grouping = False
+        for source in state.sources.values():
+            for file_id, entry in list(source.contents.items()):
+                filetype = entry.filetype
+                if not filetype:
+                    has_grouping = True
+                    continue
+                definition = self.filetype_definitions.get(filetype)
+                if definition and definition.is_standalone:
+                    asset_id = self._new_asset_id(source)
+                    source.assets[asset_id] = AssetEntry(
+                        asset_contents=[file_id],
+                    )
+                    has_standalone = True
+                else:
+                    has_grouping = True
+        next_modules: List[str] = []
+        if has_standalone and self._standalone_next:
+            next_modules.append(self._standalone_next)
+        if has_grouping and self._grouping_next:
+            next_modules.append(self._grouping_next)
+        if next_modules:
+            return state, next_modules
+        return state

--- a/tests/test_classification_service.py
+++ b/tests/test_classification_service.py
@@ -17,7 +17,9 @@ class CountingLLMClient:
         return ""
 
 
-def _make_service(llm_client: CountingLLMClient | None = None) -> ClassificationService:
+def _make_service(
+    llm_client: CountingLLMClient | None = None,
+) -> ClassificationService:
     cfg_service = ConfigService()
     cfg_service.library_config = LibraryConfig(
         FILE_TYPE_DEFINITIONS={
@@ -48,7 +50,12 @@ def test_service_builds_pipeline_and_classifies() -> None:
 def test_llm_skipped_when_all_classified() -> None:
     llm = CountingLLMClient()
     service = _make_service(llm)
-    state = ClassificationService.from_file_list(["wood_col.png", "readme.txt"])
+    state = ClassificationService.from_file_list(
+        [
+            "wood_col.png",
+            "readme.txt",
+        ]
+    )
     service.classify(state)
     assert llm.calls == 0
 
@@ -58,3 +65,27 @@ def test_from_file_list_json_roundtrip() -> None:
     text = state.to_json()
     loaded = ClassificationState.from_json(text)
     assert loaded.sources["src"].contents["0"].filename == "a.txt"
+
+
+def test_service_separates_and_groups_assets() -> None:
+    cfg_service = ConfigService()
+    cfg_service.library_config = LibraryConfig(
+        FILE_TYPE_DEFINITIONS={
+            "FILE_MODEL": FileTypeDefinition(
+                alias="MODEL", rule_keywords=["_mdl"], is_standalone=True
+            ),
+            "MAP_COL": FileTypeDefinition(alias="COL", rule_keywords=["_col"]),
+            "MAP_NRM": FileTypeDefinition(alias="NRM", rule_keywords=["_nrm"]),
+        },
+        CLASSIFICATION=ClassificationSettings(keyword_rules={}),
+    )
+    service = ClassificationService(cfg_service)
+    state = ClassificationService.from_file_list(
+        ["mesh_mdl.fbx", "mesh_col.png", "mesh_nrm.png"]
+    )
+    result = service.classify(state)
+    assets = result.sources["src"].assets
+    assert len(assets) == 2
+    assert any(asset.asset_contents == ["0"] for asset in assets.values())
+    contents_sets = [set(a.asset_contents) for a in assets.values()]
+    assert {"1", "2"} in contents_sets


### PR DESCRIPTION
## Summary
- add `SeparateStandaloneModule` to move standalone filetypes into dedicated assets with optional routing
- add `LLMGroupFilesModule` to group remaining files by path and name heuristic
- integrate Phase 2 asset grouping modules into classification service pipeline

## Testing
- `pre-commit run --files src/asset_organiser/classification/standalone.py src/asset_organiser/classification/llm_grouping.py src/asset_organiser/classification/service.py src/asset_organiser/classification/__init__.py tests/test_classification_pipeline.py tests/test_classification_service.py`
- `pip install -e .`
- `apt-get install -y libgl1`
- `apt-get install -y libxkbcommon0`
- `apt-get install -y libegl1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4267890833194ecfb998ef65f77