### PR TITLE
Add tagging stage and final pipeline output

### DIFF
--- a/src/asset_organiser/classification/__init__.py
+++ b/src/asset_organiser/classification/__init__.py
@@ -5,8 +5,10 @@ from .llm_asset_type import LLMAssetTypeModule
 from .llm_filetypes import LLMFiletypeModule
 from .llm_grouping import LLMGroupFilesModule
 from .llm_naming import LLMAssetNameModule
+from .llm_tagging import LLMTaggingModule
 from .models import ClassificationState
 from .module import ClassificationModule
+from .output import OutputModule
 from .pipeline import ClassificationPipeline
 from .rule_based import KeywordAssetTypeModule, RuleBasedFileTypeModule
 from .service import ClassificationService
@@ -26,4 +28,6 @@ __all__ = [
     "LLMAssetNameModule",
     "KeywordAssetTypeModule",
     "LLMAssetTypeModule",
+    "LLMTaggingModule",
+    "OutputModule",
 ]

--- a/src/asset_organiser/classification/llm_tagging.py
+++ b/src/asset_organiser/classification/llm_tagging.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""LLM assisted tagging module."""
+
+import re
+
+from .llm_filetypes import LLMClient, NoOpLLMClient
+from .models import ClassificationState
+from .module import ClassificationModule
+
+
+class LLMTaggingModule(ClassificationModule):
+    """Populate ``asset_tags`` for assets using a language model.
+
+    The module accepts an :class:`LLMClient` but falls back to a
+    :class:`NoOpLLMClient` to keep behaviour deterministic for tests.  When
+    the client returns an empty response, simple heuristics based on the
+    ``asset_name`` are used to generate tags.
+    """
+
+    def __init__(
+        self, client: LLMClient | None = None, prompt: str | None = None
+    ) -> None:
+        super().__init__()
+        self.client = client or NoOpLLMClient()
+        self.prompt = prompt or ""
+
+    def run(self, state: ClassificationState) -> ClassificationState:
+        for source in state.sources.values():
+            for asset in source.assets.values():
+                if asset.asset_tags:
+                    continue
+                name = asset.asset_name or ""
+                full_prompt = f"{self.prompt}\nAsset name: {name}".strip()
+                result = self.client.complete(full_prompt).strip()
+                if result:
+                    tags = [t.strip() for t in result.split(",") if t.strip()]
+                else:
+                    tags = [t for t in re.split(r"[\W_]+", name.lower()) if t]
+                asset.asset_tags.extend(tags)
+        return state

--- a/src/asset_organiser/classification/output.py
+++ b/src/asset_organiser/classification/output.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+"""Terminal output module for classification pipelines."""
+
+from .models import ClassificationState
+from .module import ClassificationModule
+
+
+class OutputModule(ClassificationModule):
+    """Final pipeline stage that simply returns the state."""
+
+    def run(self, state: ClassificationState) -> ClassificationState:
+        return state

--- a/src/asset_organiser/classification/service.py
+++ b/src/asset_organiser/classification/service.py
@@ -8,7 +8,9 @@ from .llm_asset_type import LLMAssetTypeModule
 from .llm_filetypes import LLMClient, LLMFiletypeModule, NoOpLLMClient
 from .llm_grouping import LLMGroupFilesModule
 from .llm_naming import LLMAssetNameModule
+from .llm_tagging import LLMTaggingModule
 from .models import ClassificationState
+from .output import OutputModule
 from .pipeline import ClassificationPipeline
 from .rule_based import KeywordAssetTypeModule, RuleBasedFileTypeModule
 from .standalone import AssignStandaloneNameModule, SeparateStandaloneModule
@@ -71,6 +73,10 @@ class ClassificationService:
             llm_type_module,
             after=[keyword_type_module.name],
         )
+        tagging_module = LLMTaggingModule(llm_client, classification.prompt)
+        self.pipeline.add_module(tagging_module, after=[llm_type_module.name])
+        output_module = OutputModule()
+        self.pipeline.add_module(output_module, after=[tagging_module.name])
 
     # ------------------------------------------------------------------
     def classify(self, state: ClassificationState) -> ClassificationState:

--- a/tests/test_classification_pipeline.py
+++ b/tests/test_classification_pipeline.py
@@ -12,6 +12,7 @@ from asset_organiser.classification import (
     LLMAssetNameModule,
     LLMAssetTypeModule,
     LLMGroupFilesModule,
+    LLMTaggingModule,
     RuleBasedFileTypeModule,
     SeparateStandaloneModule,
 )
@@ -336,3 +337,22 @@ def test_llm_asset_type_module_assigns_types() -> None:
     asset = state.sources["src"].assets["0"]
     assert asset.asset_type == "TYPE"
     assert client.calls == 1
+
+
+def test_llm_tagging_module_assigns_tags() -> None:
+    data = {
+        "sources": {
+            "src": {
+                "metadata": {},
+                "contents": {},
+                "assets": {"0": {"asset_name": "wood_plank"}},
+            }
+        }
+    }
+    state = ClassificationState.model_validate(data)
+    module = LLMTaggingModule(None)
+    pipeline = ClassificationPipeline()
+    pipeline.add_module(module)
+    result = pipeline.run(state)
+    asset = result.sources["src"].assets["0"]
+    assert asset.asset_tags == ["wood", "plank"]

--- a/tests/test_classification_service.py
+++ b/tests/test_classification_service.py
@@ -45,7 +45,7 @@ def test_service_builds_pipeline_and_classifies() -> None:
     assert contents["1"].filetype == "IGNORE"
     assert contents["2"].filetype is None
     assert "LLMFiletypeModule" in service.pipeline._modules
-    assert llm.calls == 7
+    assert llm.calls == 10
 
 
 def test_llm_skipped_when_all_classified() -> None:
@@ -58,7 +58,7 @@ def test_llm_skipped_when_all_classified() -> None:
         ]
     )
     service.classify(state)
-    assert llm.calls == 4
+    assert llm.calls == 6
 
 
 def test_from_file_list_json_roundtrip() -> None:
@@ -119,5 +119,8 @@ def test_service_names_and_types_assets() -> None:
     types = {a.asset_type for a in assets.values()}
     assert names == {"mesh", "wood"}
     assert types == {"MODEL", "TEXTURE"}
-    # LLM called once for naming grouped asset
-    assert llm.calls == 1
+    tags = {a.asset_name: a.asset_tags for a in assets.values()}
+    assert tags["mesh"] == ["mesh"]
+    assert tags["wood"] == ["wood"]
+    # LLM called once for naming grouped asset and twice for tagging
+    assert llm.calls == 3


### PR DESCRIPTION
## Summary
- Add `LLMTaggingModule` to generate `asset_tags` using an LLM or name-based heuristics.
- Introduce `OutputModule` as terminal stage and integrate both modules into `ClassificationService` pipeline.
- Update tests to cover tagging and adjust LLM call expectations.

## Testing
- `pre-commit run --files src/asset_organiser/classification/llm_tagging.py src/asset_organiser/classification/output.py src/asset_organiser/classification/service.py src/asset_organiser/classification/__init__.py tests/test_classification_service.py tests/test_classification_pipeline.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1fb89848331bf2c19f451520770