### PR TITLE
feat: expand classification settings

### DIFF
--- a/.asset-library/config.json
+++ b/.asset-library/config.json
@@ -15,5 +15,30 @@
     "Model": {
       "color": "#b67300"
     }
+  },
+  "CLASSIFICATION": {
+    "Active Provider": "mistral small",
+    "Prompts": {
+      "filetype": "Classify file types",
+      "asset_type": "Classify asset types",
+      "tagging": "Generate tags"
+    },
+    "Providers": [
+      {
+        "Profile Name": "mistral small",
+        "Provider": "Ollama",
+        "API Key": "",
+        "Provider-Accesspoint": "https://api.llm.gestaltservers.com",
+        "Model": "deepseek-r1:1.5b",
+        "Reasoning Effort": "Low"
+      }
+    ],
+    "Keyword Rules": {
+      "readme": "IGNORE"
+    },
+    "Asset Type Keywords": {
+      "MODEL": ["mesh"],
+      "TEXTURE": ["wood"]
+    }
   }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -2,5 +2,30 @@
   "OUTPUT_BASE_DIR": "../Asset_Library",
   "OUTPUT_DIRECTORY_PATTERN": "[supplier]/[assettype]/[assetname]",
   "OUTPUT_FILENAME_PATTERN": "[assetname]_[filetype]_[resolution]",
-  "METADATA_FILENAME": "metadata.json"
+  "METADATA_FILENAME": "metadata.json",
+  "CLASSIFICATION": {
+    "Active Provider": "mistral small",
+    "Prompts": {
+      "filetype": "Classify file types",
+      "asset_type": "Classify asset types",
+      "tagging": "Generate tags"
+    },
+    "Providers": [
+      {
+        "Profile Name": "mistral small",
+        "Provider": "Ollama",
+        "API Key": "",
+        "Provider-Accesspoint": "https://api.llm.gestaltservers.com",
+        "Model": "deepseek-r1:1.5b",
+        "Reasoning Effort": "Low"
+      }
+    ],
+    "Keyword Rules": {
+      "readme": "IGNORE"
+    },
+    "Asset Type Keywords": {
+      "MODEL": ["mesh"],
+      "TEXTURE": ["wood"]
+    }
+  }
 }

--- a/src/asset_organiser/classification/service.py
+++ b/src/asset_organiser/classification/service.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from ..config_models import AssetTypeDefinition
 from ..config_service import ConfigService
-from ..llm.client import LLMClient, NoOpLLMClient
-from ..llm.ollama import OllamaClient
-from ..llm.openai import OpenAIClient
+from ..llm import LLMClient, NoOpLLMClient, create_llm_client
 from .constants import AssignConstantsModule
 from .llm_asset_type import LLMAssetTypeModule
 from .llm_filetypes import LLMFiletypeModule
@@ -31,21 +30,23 @@ class ClassificationService:
             raise RuntimeError("Library configuration not loaded")
         classification = config_service.library_config.CLASSIFICATION
         filetype_defs = config_service.library_config.FILE_TYPE_DEFINITIONS
-        assettype_defs = config_service.library_config.ASSET_TYPE_DEFINITIONS
+        assettype_defs = dict(
+            config_service.library_config.ASSET_TYPE_DEFINITIONS
+        )
+        for atype, keywords in config_service.get_asset_type_keywords().items():
+            if atype in assettype_defs:
+                assettype_defs[atype].rule_keywords.extend(keywords)
+            else:
+                assettype_defs[atype] = AssetTypeDefinition(rule_keywords=keywords)
         self.keyword_rules = classification.keyword_rules
 
         if llm_client is None:
-            provider = (classification.provider or "").lower()
-            if provider == "openai":
-                llm_client = OpenAIClient.from_settings(
-                    classification,
-                    provider,
-                )
-            elif provider == "ollama":
-                llm_client = OllamaClient.from_settings(
-                    classification,
-                    provider,
-                )
+            profile = config_service.get_active_provider_profile()
+            if profile:
+                try:
+                    llm_client = create_llm_client(profile)
+                except Exception:
+                    llm_client = NoOpLLMClient()
             else:
                 llm_client = NoOpLLMClient()
 
@@ -53,7 +54,9 @@ class ClassificationService:
         const_module = AssignConstantsModule(self.keyword_rules)
         self.pipeline.add_module(const_module)
 
-        llm_module = LLMFiletypeModule(llm_client, classification.prompt)
+        prompts = config_service.get_classification_prompts()
+
+        llm_module = LLMFiletypeModule(llm_client, prompts.get("filetype", ""))
         rule_module = RuleBasedFileTypeModule(
             filetype_defs, next_module=llm_module.name
         )
@@ -61,7 +64,7 @@ class ClassificationService:
         self.pipeline.add_module(llm_module, after=[rule_module.name])
 
         # Phase 2: asset grouping
-        llm_type_module = LLMAssetTypeModule(llm_client, classification.prompt)
+        llm_type_module = LLMAssetTypeModule(llm_client, prompts.get("asset_type", ""))
         keyword_type_module = KeywordAssetTypeModule(
             assettype_defs, next_module=llm_type_module.name
         )
@@ -88,7 +91,7 @@ class ClassificationService:
             llm_type_module,
             after=[keyword_type_module.name],
         )
-        tagging_module = LLMTaggingModule(llm_client, classification.prompt)
+        tagging_module = LLMTaggingModule(llm_client, prompts.get("tagging", ""))
         self.pipeline.add_module(tagging_module, after=[llm_type_module.name])
         output_module = OutputModule()
         self.pipeline.add_module(output_module, after=[tagging_module.name])

--- a/src/asset_organiser/config_models.py
+++ b/src/asset_organiser/config_models.py
@@ -75,8 +75,8 @@ def _default_provider_profiles() -> List[LLMProviderProfile]:
 
 
 class ClassificationSettings(BaseModel):
-    provider: Optional[str] = Field("Ollama", alias="LLM Provider")
-    prompt: str = Field("", alias="LLM Prompt")
+    active_provider: Optional[str] = Field(None, alias="Active Provider")
+    prompts: Dict[str, str] = Field(default_factory=dict, alias="Prompts")
     providers: List[LLMProviderProfile] = Field(
         default_factory=_default_provider_profiles,
         alias="Providers",
@@ -84,6 +84,10 @@ class ClassificationSettings(BaseModel):
     keyword_rules: Dict[str, str] = Field(
         default_factory=dict,
         alias="Keyword Rules",
+    )
+    asset_type_keywords: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        alias="Asset Type Keywords",
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/src/asset_organiser/config_service.py
+++ b/src/asset_organiser/config_service.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 from pydantic import ValidationError
 
-from .config_models import GeneralSettings, LibraryConfig
+from .config_models import GeneralSettings, LibraryConfig, LLMProviderProfile
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,29 @@ class ConfigService:
         config_file = self.library_path / ".asset-library" / "config.json"
         text = self.library_config.model_dump_json(indent=2)
         config_file.write_text(text)
+
+    # ------------------------------------------------------------------
+    def get_active_provider_profile(self) -> Optional[LLMProviderProfile]:
+        if self.library_config is None:
+            return None
+        classification = self.library_config.CLASSIFICATION
+        active = classification.active_provider
+        for profile in classification.providers:
+            if profile.profile_name == active:
+                return profile
+        return classification.providers[0] if classification.providers else None
+
+    # ------------------------------------------------------------------
+    def get_classification_prompts(self) -> Dict[str, str]:
+        if self.library_config is None:
+            return {}
+        return self.library_config.CLASSIFICATION.prompts
+
+    # ------------------------------------------------------------------
+    def get_asset_type_keywords(self) -> Dict[str, List[str]]:
+        if self.library_config is None:
+            return {}
+        return self.library_config.CLASSIFICATION.asset_type_keywords
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend classification settings with active LLM provider, prompts and asset type keyword tables
- expose helper accessors in ConfigService for provider profiles, prompts and keyword tables
- wire ClassificationService to new config helpers and update sample configs

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ea36eb1083318a384fe3fae13365