### PR TITLE
Encourage review of project plans before starting work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Guidance
+
+This repository has project planning documents that explain the application's goals, architecture, and workflows. Reviewing them before starting a task helps maintain alignment and avoid rework.
+
+Recommended references:
+
+- `Implementation Plan.md` for current milestones and high-level roadmap.
+- The `ProjectPlans/` directory for detailed plans on services, UI, configuration, processing, and more.
+
+When beginning work, skim any relevant plan files to get context and ensure your changes fit within the broader vision.
+


### PR DESCRIPTION
## Summary
- add root AGENTS.md reminding contributors to consult Implementation Plan and ProjectPlans docs for context

## Testing
- `pre-commit run --files AGENTS.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'asset_organiser')*


------
https://chatgpt.com/codex/tasks/task_e_68a0eb061e648331a8c5dd7d8165ab20